### PR TITLE
feat(magic-pill): added a proper npm package publication CI using FGT

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish new releaseto npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build
+        run: npm run build
+      
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # The secret expires every 30 days, so if the CI breaks, it is likely due to the token being expired.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [8.0.5] - 2026-02-05
+### Added
+- Added a proper CI/CD pipeline to automatically publish the npm package upon release, using the fine grained token
+
 ## [8.0.4] - 2026-02-05
 ### Added
 - Added missing changelog data in `CHANGELOG.md` from versions `8.0.2` to `8.0.3` (included).


### PR DESCRIPTION
# feat(ci): Add automated npm publishing workflow with Node 22
## Summary
- Added GitHub Actions workflow for automated npm package publishing
- Updated `CHANGELOG.md` to document the new CI/CD setup
- Uses npm fine-grained tokens (FGT) for secure authentication
## Changes in Detail
### CI/CD Setup
- **New file:** `.github/workflows/publish.yml`
   - Triggers automatically when a new GitHub release is published
   - Uses Node.js 22 (current LTS) for builds
   - Runs npm ci → npm run build → npm publish
   - Authenticates using `NPM_TOKEN` secret (fine-grained token)
   - Includes helpful comment about 30-day token expiration
### Documentation
#### CHANGELOG.md
- Added v8.0.5 entry documenting the new CI/CD workflow addition
## Test Plan
- [x] Verify NPM_TOKEN secret is added to GitHub repository
- [ ] Test workflow by creating a draft release
- [ ] Confirm build completes successfully
- [ ] Verify authentication with npm registry works
- [ ] (Optional) Test with a prerelease version first
## Type of Change
- [x] New feature (CI/CD automation)
- [x] Documentation updates
- [ ] Bug fix
- [ ] Breaking change
## Benefits
- Automated publishing:** No more manual npm publish commands
- Consistency:** Same build environment every time
- Security:** Uses fine-grained tokens instead of legacy classic tokens
- **Modern stack:** Node 22 LTS for best performance and security